### PR TITLE
fix: single-day recurring alarm fires immediately when time has passed

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+<!-- 
+  Thanks for your contribution! Please fill out the sections below.
+-->
+
+### Description
+
+<!-- A clear and concise summary of what this PR does. -->
+
+Fixes #(issue) <!-- optional -->
+
+### Reasoning
+
+<!-- 
+  (Optional - for major changes)
+  Why was this change necessary?
+-->
+
+
+### Testing
+
+<!-- 
+  How did you test these changes?
+  - Unit tests added?
+  - Manual testing steps?
+-->
+
+
+### Type of change
+
+<!-- Check the ONE box that best describes your change. -->
+
+- [ ] **Bug fix** - A non-breaking change that fixes an issue
+- [ ] **New feature** - A non-breaking change that adds functionality
+- [ ] **Breaking change** - A fix or feature that would cause existing functionality to not work as expected
+- [ ] **Refactor** - A code change that neither fixes a bug nor adds a feature
+- [ ] **Docs** - Documentation only changes
+- [ ] **Tests** - Adding or updating tests
+
+### Checklist
+
+- [ ] I have tested my changes locally
+- [ ] I have added/updated unit tests (if applicable)
+- [ ] My code follows the project's code style

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,96 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - main
+    paths-ignore:
+      - '.idea/**'
+      - '.gitattributes'
+      - '.gitignore'
+      - '**.md'
+      - 'LICENSE'
+  pull_request:
+    paths-ignore:
+      - '.idea/**'
+      - '.gitattributes'
+      - '.gitignore'
+      - '**.md'
+      - 'LICENSE'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 17
+          
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        
+      - name: Build library
+        run: ./gradlew :smplralarm:assembleRelease
+        
+      - name: Upload AAR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: smplralarm-release
+          path: smplralarm/build/outputs/aar/*.aar
+          retention-days: 7
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 17
+          
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        
+      - name: Run unit tests
+        run: ./gradlew :smplralarm:testDebugUnitTest
+        
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: smplralarm/build/reports/tests/
+          retention-days: 7
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 17
+          
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        
+      - name: Run lint
+        run: ./gradlew :smplralarm:lint
+        
+      - name: Upload lint results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-results
+          path: smplralarm/build/reports/lint-results*.html
+          retention-days: 7

--- a/smplralarm/src/test/java/de/coldtea/smplr/smplralarm/TimeHelpersTest.kt
+++ b/smplralarm/src/test/java/de/coldtea/smplr/smplralarm/TimeHelpersTest.kt
@@ -1,13 +1,21 @@
 package de.coldtea.smplr.smplralarm
 
 import de.coldtea.smplr.smplralarm.models.DefaultAlarmTimeCalculator
+import de.coldtea.smplr.smplralarm.models.WeekDays
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.util.Calendar
 
 class TimeHelpersTest {
 
     private val calculator = DefaultAlarmTimeCalculator()
+    private val utcZone = ZoneId.of("UTC")
 
     @Test
     fun secondDifference_isOneSecond() {
@@ -59,5 +67,111 @@ class TimeHelpersTest {
 
         val diff = plusOneMillis - base
         assertEquals(1L, diff)
+    }
+
+    /**
+     * Regression test for single-day recurring alarm bug.
+     *
+     * Scenario: It's Sunday at 15:51, and we set an alarm for 15:00 on Sundays only.
+     * Expected: The alarm should be scheduled for NEXT Sunday (7 days later), not today.
+     * Bug: Previously, the fallback loop would reset to today and return today's date,
+     *      causing the alarm to fire immediately since 15:00 has already passed.
+     */
+    @Test
+    fun singleDayRecurringAlarm_withPassedTime_schedulesForNextWeek() {
+        // Given: Sunday Feb 22, 2026 at 15:51:00 UTC
+        val sundayAt1551 = ZonedDateTime.of(2026, 2, 22, 15, 51, 0, 0, utcZone)
+        val fixedClock = Clock.fixed(sundayAt1551.toInstant(), utcZone)
+        val testCalculator = DefaultAlarmTimeCalculator(utcZone, fixedClock)
+
+        // When: Calculate next trigger for 15:00 on Sundays only
+        val nextTriggerMillis = testCalculator.computeNextTriggerTimeMillis(
+            hour = 15,
+            minute = 0,
+            second = 0,
+            millis = 0,
+            weekDays = listOf(WeekDays.SUNDAY),
+        )
+
+        // Then: Should be next Sunday (March 1, 2026), not today
+        val nextTriggerDate = Instant.ofEpochMilli(nextTriggerMillis)
+            .atZone(utcZone)
+            .toLocalDate()
+
+        // Next Sunday is March 1, 2026
+        val expectedDate = LocalDate.of(2026, 3, 1)
+        assertEquals(expectedDate, nextTriggerDate)
+
+        // Also verify the trigger time is in the future
+        assertTrue(
+            "Next trigger should be after now",
+            nextTriggerMillis > sundayAt1551.toInstant().toEpochMilli()
+        )
+    }
+
+    /**
+     * Test that multi-day recurring alarms still work correctly.
+     *
+     * Scenario: It's Sunday at 15:51, alarm for 9:00 on all weekdays.
+     * Expected: Should schedule for Monday 9:00.
+     */
+    @Test
+    fun multiDayRecurringAlarm_withPassedTime_schedulesForNextValidDay() {
+        // Given: Sunday Feb 22, 2026 at 15:51:00 UTC
+        val sundayAt1551 = ZonedDateTime.of(2026, 2, 22, 15, 51, 0, 0, utcZone)
+        val fixedClock = Clock.fixed(sundayAt1551.toInstant(), utcZone)
+        val testCalculator = DefaultAlarmTimeCalculator(utcZone, fixedClock)
+
+        // When: Calculate next trigger for 9:00 on all days
+        val nextTriggerMillis = testCalculator.computeNextTriggerTimeMillis(
+            hour = 9,
+            minute = 0,
+            second = 0,
+            millis = 0,
+            weekDays = listOf(
+                WeekDays.MONDAY,
+                WeekDays.TUESDAY,
+                WeekDays.WEDNESDAY,
+                WeekDays.THURSDAY,
+                WeekDays.FRIDAY,
+                WeekDays.SATURDAY,
+                WeekDays.SUNDAY,
+            ),
+        )
+
+        // Then: Should be Monday Feb 23, 2026 at 9:00
+        val nextTrigger = Instant.ofEpochMilli(nextTriggerMillis).atZone(utcZone)
+        val expectedDate = LocalDate.of(2026, 2, 23)
+        assertEquals(expectedDate, nextTrigger.toLocalDate())
+        assertEquals(9, nextTrigger.hour)
+    }
+
+    /**
+     * Test that same-day alarms work when time hasn't passed yet.
+     *
+     * Scenario: It's Sunday at 14:00, alarm for 15:00 on Sundays.
+     * Expected: Should schedule for today at 15:00.
+     */
+    @Test
+    fun singleDayRecurringAlarm_withFutureTime_schedulesForToday() {
+        // Given: Sunday Feb 22, 2026 at 14:00:00 UTC
+        val sundayAt1400 = ZonedDateTime.of(2026, 2, 22, 14, 0, 0, 0, utcZone)
+        val fixedClock = Clock.fixed(sundayAt1400.toInstant(), utcZone)
+        val testCalculator = DefaultAlarmTimeCalculator(utcZone, fixedClock)
+
+        // When: Calculate next trigger for 15:00 on Sundays only
+        val nextTriggerMillis = testCalculator.computeNextTriggerTimeMillis(
+            hour = 15,
+            minute = 0,
+            second = 0,
+            millis = 0,
+            weekDays = listOf(WeekDays.SUNDAY),
+        )
+
+        // Then: Should be today (Sunday Feb 22, 2026) at 15:00
+        val nextTrigger = Instant.ofEpochMilli(nextTriggerMillis).atZone(utcZone)
+        val expectedDate = LocalDate.of(2026, 2, 22)
+        assertEquals(expectedDate, nextTrigger.toLocalDate())
+        assertEquals(15, nextTrigger.hour)
     }
 }


### PR DESCRIPTION
## Summary

Fixes a bug where single-day recurring alarms (e.g., Sundays only) fire immediately and repeatedly when the scheduled time has already passed for today.

The fallback loop was resetting to today instead of continuing from next week, causing the alarm to return a past date.

Adds regression tests and makes the calculator testable via Clock injection.

## Changes

- Remove erroneous date reset in `computeNextDateForRepeating()` fallback loop
- Add `Clock` parameter to `DefaultAlarmTimeCalculator` for testability
- Add unit tests covering single-day edge case

## Testing

- [x] Unit tests added for single-day recurring alarm scenario
- [x] Existing tests still pass